### PR TITLE
LoopOperation missing repetitions property

### DIFF
--- a/quantify_scheduler/operations/control_flow_library.py
+++ b/quantify_scheduler/operations/control_flow_library.py
@@ -109,6 +109,11 @@ class LoopOperation(ControlFlowOperation):
             * self.data["control_flow_info"]["body"].duration
         )
 
+    @property
+    def repetitions(self) -> int:
+        """Number of repetitions in the control flow loop."""
+        return self.data["control_flow_info"]["repetitions"]
+
 
 class ConditionalOperation(ControlFlowOperation):
     """


### PR DESCRIPTION
When plotting a pulse diagram for a Schedule that contains a LoopOperation, an error arises at `quantify_scheduler/schedules/_visualization/pulse_diagram.py` line 353 which assumes that LoopOperation has a repetitions property:

```
    elif isinstance(operation, LoopOperation):
        for i in range(operation.repetitions):
            _extract_schedule_infos(
                operation.body,
                port_list,
                time_offset + i * operation.body.duration,
                offset_infos,
                pulse_infos,
                acq_infos,
            )
```

I fixed the issue by adding the property.